### PR TITLE
Disable XF86 media keys

### DIFF
--- a/config/X11/xmodmap/.xmodmap
+++ b/config/X11/xmodmap/.xmodmap
@@ -53,13 +53,13 @@ keycode 134 = NoSymbol
 ! Allow Numpad keys
 
 ! Allow Add
-! keycode  86 = KP_Add KP_Add KP_Add KP_Add KP_Add KP_Add XF86Next_VMode KP_Add KP_Add XF86Next_VMode
+! keycode 86 = KP_Add KP_Add KP_Add KP_Add KP_Add KP_Add XF86Next_VMode KP_Add KP_Add XF86Next_VMode
 
 ! Allow Subtract
-! keycode  82 = KP_Subtract KP_Subtract KP_Subtract KP_Subtract KP_Subtract KP_Subtract XF86Prev_VMode KP_Subtract KP_Subtract XF86Prev_VMode
+! keycode 82 = KP_Subtract KP_Subtract KP_Subtract KP_Subtract KP_Subtract KP_Subtract XF86Prev_VMode KP_Subtract KP_Subtract XF86Prev_VMode
 
 ! Allow Multiply
-! keycode  63 = KP_Multiply KP_Multiply KP_Multiply KP_Multiply KP_Multiply KP_Multiply XF86ClearGrab KP_Multiply KP_Multiply XF86ClearGrab
+! keycode 63 = KP_Multiply KP_Multiply KP_Multiply KP_Multiply KP_Multiply KP_Multiply XF86ClearGrab KP_Multiply KP_Multiply XF86ClearGrab
 
 ! Allow Divide
 ! keycode 106 = KP_Divide KP_Divide KP_Divide KP_Divide KP_Divide KP_Divide XF86Ungrab KP_Divide KP_Divide XF86Ungrab
@@ -67,7 +67,7 @@ keycode 134 = NoSymbol
 
 ! Disable extra (media) XF86 keys
 
-! Disable everything else
+! Disable everything else (these are ALL XF86 media controls)
 keycode 121 = NoSymbol
 keycode 122 = NoSymbol
 keycode 123 = NoSymbol

--- a/test/bcld.md5
+++ b/test/bcld.md5
@@ -18,7 +18,7 @@ b1447f0cf092dc2f9c8770aaedd8fb5f  ./SECURITY.md
 5ee37144e15f8bf49e7f683935a27f15  ./assets/bcld-logo.png
 7fd61304876342f4986b024ae89af821  ./config/BUILD.conf
 f9308ddcf62532c70ae0b4970c39b082  ./config/X11/xbindkeys/.xbindkeysrc
-1ec9d5b19d19cd01d6046371e6aeb42b  ./config/X11/xmodmap/.xmodmap
+2bd011392d7c87070a19a6733fcc03dc  ./config/X11/xmodmap/.xmodmap
 12e8a46bb563daf82e8ce5fc143cf69b  ./config/X11/xorg.conf.d/80-bcld-basic.conf
 1dd0fe36979d5936d50b4b6065a41437  ./config/X11/xorg.conf.nvidia/30-nvidia.conf
 cfc9284e73df9db03f57d490adfa71a2  ./config/X11/xorg.conf.test/99-bcld-disable-kiosk.conf

--- a/test/md5sum
+++ b/test/md5sum
@@ -1,1 +1,1 @@
-9c9df0fc76d0cccb8235b0c60ec2ea0f  ./test/bcld.md5
+2ac348c4a971b3fe1eb2e87de7d0659f  ./test/bcld.md5


### PR DESCRIPTION
Extra media toetsen uitgeschakeld middels xmodmap; deze keys staan bijna nooit ALLEMAAL op 1 keyboard.
Dit zijn vaak selectieve toetsen, fabrikanten kiezen zelf welke toetscodes ze willen ondersteunen.

We schakelen ze hierbij allemaal uit.